### PR TITLE
Stability when extrinsics fail

### DIFF
--- a/src/backend/utilities/attestClaim.ts
+++ b/src/backend/utilities/attestClaim.ts
@@ -23,12 +23,19 @@ export async function attestClaim(
     requestForAttestation,
     configuration.did,
   );
+  const { claimHash } = attestation;
+
+  const alreadyAttested = Boolean(await Attestation.query(claimHash));
+  if (alreadyAttested) {
+    // We see some attestations extrinsic failing as already attested, check for it early
+    return attestation;
+  }
 
   try {
     await batchSignAndSubmitAttestation(attestation);
   } catch (exception) {
     // It happens that despite the error the attestation has gone through, do not fail then
-    const attested = Boolean(await Attestation.query(attestation.claimHash));
+    const attested = Boolean(await Attestation.query(claimHash));
     if (!attested) {
       throw exception;
     }

--- a/src/backend/utilities/batchSignAndSubmitAttestation.ts
+++ b/src/backend/utilities/batchSignAndSubmitAttestation.ts
@@ -102,12 +102,22 @@ async function createPendingTransaction() {
   logger.debug('Transaction submitted');
 }
 
-export async function batchSignAndSubmitAttestation(attestation: Attestation) {
-  // prevent two identical attestations from going into the same batch
-  const alreadyAdded = pendingAttestations.some(
+function alreadyAddedTo(
+  list: AttemptedAttestation[],
+  attestation: Attestation,
+) {
+  return list.some(
     ({ attestation: { claimHash } }) => claimHash === attestation.claimHash,
   );
-  if (!alreadyAdded) {
+}
+
+export async function batchSignAndSubmitAttestation(attestation: Attestation) {
+  // prevent two identical attestations from going into the same batch
+  if (alreadyAddedTo(currentAttestations, attestation)) {
+    return currentTransaction;
+  }
+
+  if (!alreadyAddedTo(pendingAttestations, attestation)) {
     pendingAttestations.push({ attestation, failures: 0 });
   }
 


### PR DESCRIPTION
* early check whether already attested
* independent outcomes for batched extrinsics
* limit failed attestation attempts
* check current attestations for existing one