### PR TITLE
SK-1244: init metrics

### DIFF
--- a/src/backend/endpoints/metrics.ts
+++ b/src/backend/endpoints/metrics.ts
@@ -11,14 +11,14 @@ export const attestSuccess = new Counter({
   help: 'attestation_success_count',
   labelNames: ['credential_type'],
 });
-attestSuccess.inc(0);
+attestSuccess.inc({ credential_type: 'dummyInit' }, 0);
 
 export const attestFail = new Counter({
   name: 'attestation_failed_count',
   help: 'attestation_failed_count',
   labelNames: ['credential_type'],
 });
-attestFail.inc(0);
+attestFail.inc({ credential_type: 'dummyInit' }, 0);
 
 export const attestDurationSeconds = new Histogram({
   name: 'attestation_duration_s',

--- a/src/backend/endpoints/metrics.ts
+++ b/src/backend/endpoints/metrics.ts
@@ -11,12 +11,14 @@ export const attestSuccess = new Counter({
   help: 'attestation_success_count',
   labelNames: ['credential_type'],
 });
+attestSuccess.inc(0);
 
 export const attestFail = new Counter({
   name: 'attestation_failed_count',
   help: 'attestation_failed_count',
   labelNames: ['credential_type'],
 });
+attestFail.inc(0);
 
 export const attestDurationSeconds = new Histogram({
   name: 'attestation_duration_s',


### PR DESCRIPTION
this change makes it explicit and more trackable how we initialize the counters
![image](https://user-images.githubusercontent.com/34937334/190396932-c99dc0ef-3259-4037-b050-79ace07763ec.png)
