### PR TITLE
Bump node to v18

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -10,7 +10,7 @@ jobs:
       - name: Configure Node and package manager
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: '16'
+          node-version: '18.12.0'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS base
+FROM node:18.12.0-alpine AS base
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "UNLICENSED",
   "type": "module",
   "engines": {
-    "node": ">= v16.17.0"
+    "node": ">= v18.12.0"
   },
   "scripts": {
     "prettify": "prettier --write \"src/**/*.ts*\"",
@@ -14,7 +14,7 @@
     "test": "tsc --noEmit && LC_ALL=en_US.UTF-8 jest",
     "storybook": "start-storybook --port 6007 --modern",
     "dev": "yarn parcel watch",
-    "build": "yarn parcel build",
+    "build": "NODE_OPTIONS=--no-experimental-fetch yarn parcel build",
     "start": "node --enable-source-maps dist/backend/server.js",
     "dev-start": "echo '{\"type\":\"commonjs\"}' > dist/package.json && supervisor --watch dist/backend/ -- --enable-source-maps dist/backend/server.js"
   },


### PR DESCRIPTION
The NODE_OPTIONS override can be removed when a newer version of Parcel gets the latest version of Terser https://github.com/parcel-bundler/parcel/issues/8005