### PR TITLE
workaround for yield undefined

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN yarn install --immutable && yarn add --dev @parcel/css-linux-x64-musl && yar
 
 # get the sources and build the app
 COPY src ./src
-COPY tsconfig.json ./
+COPY tsconfig.json .babelrc.js ./
 RUN yarn build
 
 FROM base AS release

--- a/src/backend/revoker/expiredInventory.ts
+++ b/src/backend/revoker/expiredInventory.ts
@@ -1,5 +1,4 @@
 import { sleep } from '../utilities/sleep';
-import { logger } from '../utilities/logger';
 
 import { getExpiredAttestations } from './getExpiredAttestations';
 import { AttestationInfo } from './scanAttestations';
@@ -25,9 +24,6 @@ export async function fillExpiredInventory() {
       attestationsToRemoveLater.push(expiredAttestation);
     }
   }
-  logger.debug('attestationsToRemoveLater: ', attestationsToRemoveLater);
-  logger.debug('attestationsToRevoke: ', attestationsToRevoke);
-  logger.debug('attestationsToRemove: ', attestationsToRemove);
 }
 
 const SCAN_INTERVAL_MS = 60 * 60 * 1000;

--- a/src/backend/revoker/getExpiredAttestations.ts
+++ b/src/backend/revoker/getExpiredAttestations.ts
@@ -12,15 +12,13 @@ import { scanAttestations } from './scanAttestations';
  */
 export function getExpiredAttestations() {
   const allAttestations = scanAttestations();
-  const ourAttestations = filterGenerator(
+  const own = filterGenerator(
     allAttestations,
-    async (attestation) => {
-      return attestation && attestation.owner === configuration.did;
-    },
+    async ({ owner }) => owner === configuration.did,
   );
-  const existing = filterGenerator(ourAttestations, async (attestation) => {
-    // return only attestations still on chain, not removed
-    return attestation && attestation.revoked !== null;
-  });
+  const existing = filterGenerator(
+    own,
+    async ({ revoked }) => revoked !== null, // still present on the blockchain
+  );
   return existing;
 }

--- a/src/backend/revoker/scanAttestations.ts
+++ b/src/backend/revoker/scanAttestations.ts
@@ -32,15 +32,10 @@ export async function* scanAttestations() {
       const allRevoked = await batchQueryRevoked(claimHashes);
 
       // add the revocation status as a new parameter
-      events.forEach((event) => {
-        const { params } = event;
-        logger.debug('event before transformation', event);
-
+      events.forEach(({ params }) => {
         const claimHash = params[1].value;
         params.push(allRevoked[claimHash]);
-        logger.debug('params of the transformed event', params);
       });
-
       return events;
     },
   );
@@ -52,7 +47,6 @@ export async function* scanAttestations() {
     if (!shouldBeRevoked({ createdAt })) {
       logger.debug('No more attestations to revoke');
       // stop here so that fromBlock contains the last expired block, and we can start from it in the next run
-
       return;
     }
     fromBlock = block;

--- a/src/backend/revoker/scanAttestations.ts
+++ b/src/backend/revoker/scanAttestations.ts
@@ -34,11 +34,11 @@ export async function* scanAttestations() {
       // add the revocation status as a new parameter
       events.forEach((event) => {
         const { params } = event;
-        logger.debug(`event before transformation ${event}`);
+        logger.debug('event before transformation', event);
 
         const claimHash = params[1].value;
         params.push(allRevoked[claimHash]);
-        logger.debug(`params of the transformed event ${params}`);
+        logger.debug('params of the transformed event', params);
       });
 
       return events;

--- a/src/backend/revoker/scanAttestations.ts
+++ b/src/backend/revoker/scanAttestations.ts
@@ -34,13 +34,11 @@ export async function* scanAttestations() {
       // add the revocation status as a new parameter
       events.forEach((event) => {
         const { params } = event;
-        logger.debug(`event before transformation ${JSON.stringify(event)}`);
+        logger.debug(`event before transformation ${event}`);
 
         const claimHash = params[1].value;
         params.push(allRevoked[claimHash]);
-        logger.debug(
-          `params of the transformed event ${JSON.stringify(params)}`,
-        );
+        logger.debug(`params of the transformed event ${params}`);
       });
 
       return events;
@@ -66,7 +64,7 @@ export async function* scanAttestations() {
     const delegationId = params[3].value;
     const revoked = params[4];
 
-    const attestation = {
+    yield <AttestationInfo>{
       owner,
       claimHash,
       cTypeHash,
@@ -75,11 +73,5 @@ export async function* scanAttestations() {
       block,
       createdAt,
     };
-    logger.debug(
-      `attestation being yield:
-      ${typeof attestation},
-      ${JSON.stringify(attestation)}`,
-    );
-    yield <AttestationInfo>attestation;
   }
 }

--- a/src/backend/revoker/subScan.ts
+++ b/src/backend/revoker/subScan.ts
@@ -124,7 +124,6 @@ export async function* subScanEventGenerator(
         `Loaded events page ${page} for ${call} in block range ${blockRange}`,
       );
       for (const event of await transform(events)) {
-        logger.debug('event being yield', event);
         yield event;
       }
 

--- a/src/backend/revoker/subScan.ts
+++ b/src/backend/revoker/subScan.ts
@@ -125,6 +125,11 @@ export async function* subScanEventGenerator(
           `Loaded events page ${page} for ${call} in block range ${blockRange}`,
         );
         for (const event of await transform(events)) {
+          logger.debug(
+            `event being yield:
+            ${typeof event},
+            ${JSON.stringify(event)}`,
+          );
           yield event;
         }
 

--- a/src/backend/revoker/subScan.ts
+++ b/src/backend/revoker/subScan.ts
@@ -126,9 +126,9 @@ export async function* subScanEventGenerator(
         );
         for (const event of await transform(events)) {
           logger.debug(
-            `event being yield:
-            ${typeof event},
-            ${JSON.stringify(event)}`,
+            'event being yield',
+            typeof event,
+            JSON.stringify(event),
           );
           yield event;
         }

--- a/src/backend/utilities/filterGenerator.ts
+++ b/src/backend/utilities/filterGenerator.ts
@@ -1,5 +1,3 @@
-import { logger } from './logger';
-
 export function filterGenerator<Value>(
   generator: AsyncGenerator<Value>,
   predicate: (value: Value) => Promise<boolean>,
@@ -7,11 +5,6 @@ export function filterGenerator<Value>(
   return (async function* () {
     for await (const value of generator) {
       if (await predicate(value)) {
-        logger.debug(
-          `value being yield, from filterG:
-          ${typeof value},
-          ${JSON.stringify(value)}`,
-        );
         yield value;
       }
     }


### PR DESCRIPTION
The code built inside the container was generated incorrectly, omitting the value to yield. This is likely a bug in the older esbuild transpiler we’re using. This was not reproducible locally because of the presence of babel configuration, which turned on the transpilation by babel instead. Adding it in the container results in correct code being generated and works around the issue.