### PR TITLE
fix: quickly skyc dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@types/hapi__inert": "^5.2.10",
     "@types/jest": "^29.5.11",
     "@types/lodash-es": "^4.17.12",
-    "@types/node": "^20.11.15",
+    "@types/node": "20.11.13",
     "@types/react": "^18.2.51",
     "@types/react-dom": "^18.2.18",
     "@types/react-router-dom": "^5.3.3",

--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,10 @@
       "matchPackagePatterns": ["polkadot"],
       "groupName": "polkadot",
       "automerge": false
+    },
+    {
+      "matchPackageNames": ["@types/node"],
+      "enabled": false
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,12 +7339,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:^20.11.15":
+"@types/node@npm:*":
   version: 20.11.15
   resolution: "@types/node@npm:20.11.15"
   dependencies:
     undici-types: "npm:~5.26.4"
   checksum: 10c0/7dfab4208fedc02e9584c619551906f46ade7955bb929b1e32e354a50522eb532d6bfb2844fdaad2c8dca03be84a590674460c64cb101e1a33bb318e1ec448d4
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.11.13":
+  version: 20.11.13
+  resolution: "@types/node@npm:20.11.13"
+  dependencies:
+    undici-types: "npm:~5.26.4"
+  checksum: 10c0/8ff8526fa0dbabcf4e9c538c6a7220675f750c39d0794e34998daa0656d7e0dfdf3e47403d2ab8beb756422a517e1f2646b4494afa59ef330495d65fc58fa4d8
   languageName: node
   linkType: hard
 
@@ -16645,7 +16654,7 @@ __metadata:
     "@types/hapi__inert": "npm:^5.2.10"
     "@types/jest": "npm:^29.5.11"
     "@types/lodash-es": "npm:^4.17.12"
-    "@types/node": "npm:^20.11.15"
+    "@types/node": "npm:20.11.13"
     "@types/react": "npm:^18.2.51"
     "@types/react-dom": "npm:^18.2.18"
     "@types/react-router-dom": "npm:^5.3.3"


### PR DESCRIPTION
Temporary fix for dev.SocialKYC.io:

Downgrade  @types/node to version 20.11.13 and make renovate-bot ignore @types/node packages.