### PR TITLE
feat: continue working on indexer's absence

### DIFF
--- a/src/backend/revoker/indexer/queryFromIndexer.ts
+++ b/src/backend/revoker/indexer/queryFromIndexer.ts
@@ -98,7 +98,7 @@ export async function queryFromIndexer<ExpectedQueryResults>(query: string) {
 export async function* matchesGenerator<ExpectedQueryResults>(
   buildQuery: (offset: number) => string,
 ): AsyncGenerator<ExpectedQueryResults, void> {
-  if (indexer.graphqlEndpoint === 'NONE') {
+  if (String(indexer.graphqlEndpoint).toUpperCase() === 'NONE') {
     return;
   }
   const query = buildQuery(0);


### PR DESCRIPTION
Stop the app from crashing due to Error Responses from the Indexer. 

It also improves the handling of the environment variable stored on `indexer.graphqlEndpoint`.
Now 'none' is case insensitive. 